### PR TITLE
dump stack creation events when it fails

### DIFF
--- a/TTC.Deployment.AmazonWebServices/Deployer.cs
+++ b/TTC.Deployment.AmazonWebServices/Deployer.cs
@@ -93,7 +93,8 @@ namespace TTC.Deployment.AmazonWebServices
             }
             if (status != StackStatus.CREATE_COMPLETE)
             {
-                throw new FailedToCreateStackException(stackName, status.Value, statusReason);
+                var eventsResponse = _cloudFormationClient.DescribeStackEvents(new DescribeStackEventsRequest { StackName = stackName });
+                throw new FailedToCreateStackException(stackName, _awsConfiguration.AwsEndpoint, status.Value, statusReason, eventsResponse.StackEvents);
             }
         }
 

--- a/TTC.Deployment.AmazonWebServices/FailedToCreateStackException.cs
+++ b/TTC.Deployment.AmazonWebServices/FailedToCreateStackException.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon;
+using Amazon.CloudFormation.Model;
 
 namespace TTC.Deployment.AmazonWebServices
 {
     public class FailedToCreateStackException : Exception
     {
-        public FailedToCreateStackException(string stackName, string status, string statusReason)
-            : base(string.Format("Failed to create stack {0}: {1}\n{2}", stackName, status, statusReason))
+        public FailedToCreateStackException(string stackName, RegionEndpoint awsEndpoint, string status, string statusReason, IEnumerable<StackEvent> stackEvents)
+            : base(string.Format("Failed to create stack {0} (in {1}): {2}\n{3}\n\nEVENTS:\n\n{4}",
+                stackName, awsEndpoint, status, statusReason, string.Join(Environment.NewLine, stackEvents.Select(e => e.ResourceType + ": " + e.ResourceStatusReason).ToArray())))
         {
         }
     }


### PR DESCRIPTION
Exposes reasons for individual resources failing, when creating a stack fails, like these:

![error-events](https://cloud.githubusercontent.com/assets/22017/10313320/fceac9d2-6c46-11e5-9284-fdabd9c16b0d.PNG)
