### PR TITLE
Remove eips from windows vpc template

### DIFF
--- a/TTC.Deployment.Tests/ProvisioningTest.cs
+++ b/TTC.Deployment.Tests/ProvisioningTest.cs
@@ -16,7 +16,7 @@ namespace TTC.Deployment.Tests
     {
         private AwsConfiguration _awsConfiguration;
         private AmazonCloudFormationClient _cloudFormationClient;
-        const string StackName = "TestEnv1";
+        const string StackName = "AwsToolsTestVPC";
 
         [SetUp]
         public void SetUp()
@@ -43,7 +43,7 @@ namespace TTC.Deployment.Tests
         }
 
         [Test]
-        public void CreatesCloud()
+        public void CreatesVirtualPrivateCloudWithWindowsMachines()
         {
             var deployer = new Deployer(_awsConfiguration);
         

--- a/TTC.Deployment.Tests/example-windows-vpc-template.json
+++ b/TTC.Deployment.Tests/example-windows-vpc-template.json
@@ -112,6 +112,7 @@
                 ],
                 "NetworkInterfaces": [
                     {
+						"AssociatePublicIpAddress": true,
                         "DeleteOnTermination": "true",
                         "Description": "Primary network interface",
                         "DeviceIndex": 0,
@@ -198,6 +199,7 @@
                 ],
                 "NetworkInterfaces": [
                     {
+						"AssociatePublicIpAddress": true,
                         "DeleteOnTermination": "true",
                         "Description": "Primary network interface",
                         "DeviceIndex": 0,
@@ -386,6 +388,18 @@
                     "Ref": "securityGroup1"
                 },
                 "IpProtocol": "-1",
+                "CidrIp": "0.0.0.0/0"
+            }
+        },
+        "egress2": {
+            "Type": "AWS::EC2::SecurityGroupEgress",
+            "Properties": {
+                "GroupId": {
+                    "Ref": "securityGroup1"
+                },
+                "IpProtocol": "tcp",
+                "FromPort": "80",
+                "ToPort": "80",
                 "CidrIp": "0.0.0.0/0"
             }
         }

--- a/TTC.Deployment.Tests/example-windows-vpc-template.json
+++ b/TTC.Deployment.Tests/example-windows-vpc-template.json
@@ -63,16 +63,6 @@
                 "VpcId": { "Ref": "vpc1" }
             }
         },
-        "webServerEIP": {
-            "Type": "AWS::EC2::EIP",
-            "DependsOn": [ "gatewayAttachment1" ],
-            "Properties": { "Domain": "vpc1" }
-        },
-        "internalApiServerEIP": {
-            "Type": "AWS::EC2::EIP",
-            "DependsOn": [ "gatewayAttachment1" ],
-            "Properties": { "Domain": "vpc1" }
-        },
         "webServer": {
             "Type": "AWS::EC2::Instance",
             "Metadata": { },
@@ -100,7 +90,7 @@
 
                 "DisableApiTermination": "false",
                 "InstanceInitiatedShutdownBehavior": "stop",
-                "ImageId": "ami-417bcf2a",
+                "ImageId": "ami-c9cea0ac",
                 "InstanceType": "t2.small",
                 "KeyName": "WindowsTestKey",
                 "Monitoring": "false",
@@ -150,7 +140,7 @@
 
         "webServerWaitCondition": {
             "Type": "AWS::CloudFormation::WaitCondition",
-            "DependsOn": [ "webServer", "webServerEIP" ],
+            "DependsOn": [ "webServer" ],
             "Properties": {
                 "Handle": { "Ref": "webServerWaitHandle" },
                 "Timeout": "1200"
@@ -186,7 +176,7 @@
 
                 "DisableApiTermination": "false",
                 "InstanceInitiatedShutdownBehavior": "stop",
-                "ImageId": "ami-417bcf2a",
+                "ImageId": "ami-c9cea0ac",
                 "InstanceType": "t2.small",
                 "KeyName": "WindowsTestKey",
                 "Monitoring": "false",
@@ -236,7 +226,7 @@
 
         "internalApiServerWaitCondition": {
             "Type": "AWS::CloudFormation::WaitCondition",
-            "DependsOn": [ "internalApiServer", "internalApiServerEIP" ],
+            "DependsOn": [ "internalApiServer" ],
             "Properties": {
                 "Handle": { "Ref": "internalApiServerWaitHandle" },
                 "Timeout": "2000"
@@ -353,34 +343,6 @@
                 }
             }
         },
-        "webServerEipAssociation": {
-            "Type": "AWS::EC2::EIPAssociation",
-            "Properties": {
-                "AllocationId": {
-                    "Fn::GetAtt": [
-                        "webServerEIP",
-                        "AllocationId"
-                    ]
-                },
-                "InstanceId": {
-                    "Ref": "webServer"
-                }
-            }
-        },
-        "internalApiServerEipAssociation": {
-            "Type": "AWS::EC2::EIPAssociation",
-            "Properties": {
-                "AllocationId": {
-                    "Fn::GetAtt": [
-                        "internalApiServerEIP",
-                        "AllocationId"
-                    ]
-                },
-                "InstanceId": {
-                    "Ref": "internalApiServer"
-                }
-            }
-        },
         "ingress1": {
             "Type": "AWS::EC2::SecurityGroupIngress",
             "Properties": {
@@ -427,11 +389,5 @@
                 "CidrIp": "0.0.0.0/0"
             }
         }
-    },
-  "Outputs" : {
-    "elasticIpUrl" : {
-      "Value" : { "Fn::Join" : ["", ["http://", { "Ref" : "webServerEIP" } ]] },
-      "Description" : "The public IP address"
     }
-  }
 }


### PR DESCRIPTION
**Not ready to merge yet**

@PaulCampbell can you give me a hand with this? We've locked down accounts so that most users can't create EIPs, which means the tests fail because they can't see the internet to trigger the waitCondition thingy... I guess I need to fiddle with the security groups or something?