### PR TITLE
Feature/saving stack output

### DIFF
--- a/AWSProvisionCloud/Program.cs
+++ b/AWSProvisionCloud/Program.cs
@@ -15,7 +15,8 @@ namespace AWSCloudProvision
             var deployer = new Deployer(new AwsConfiguration
             {
                 AwsEndpoint = RegionEndpoint.USEast1,
-                Proxy = new AwsProxy { Host = options.ProxyHost, Port = options.ProxyPort }
+                Proxy = new AwsProxy { Host = options.ProxyHost, Port = options.ProxyPort },
+                StackOutputFile = options.StackOutputFile
             });
             deployer.CreateStack(new StackTemplate
             {
@@ -41,6 +42,9 @@ namespace AWSCloudProvision
 
         [Option('x', "proxyPort", Required = false, HelpText = "The proxy port")]
         public int ProxyPort { get; set; }
+
+        [Option('o', "stackOutputFile", Required = false, HelpText = "File path where stack output will be saved after stack creation")]
+        public string StackOutputFile { get; set; }
 
         [HelpOption]
         public string GetUsage()

--- a/TTC.Deployment.AmazonWebServices/AwsConfiguration.cs
+++ b/TTC.Deployment.AmazonWebServices/AwsConfiguration.cs
@@ -11,6 +11,7 @@ namespace TTC.Deployment.AmazonWebServices
         public string RoleName { get; set; }
         public RegionEndpoint AwsEndpoint { get; set; }
         public AwsProxy Proxy { get; set; }
+        public string StackOutputFile { get; set; }
     }
 
     public class AwsProxy 

--- a/TTC.Deployment.AmazonWebServices/Deployer.cs
+++ b/TTC.Deployment.AmazonWebServices/Deployer.cs
@@ -13,6 +13,8 @@ using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Amazon.S3;
 using Amazon.S3.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace TTC.Deployment.AmazonWebServices
 {
@@ -70,8 +72,9 @@ namespace TTC.Deployment.AmazonWebServices
             });
 
             WaitForStack(stackName);
-            var stack =
-                _cloudFormationClient.DescribeStacks(new DescribeStacksRequest {StackName = stackName}).Stacks.First();
+            var stack = _cloudFormationClient.DescribeStacks(new DescribeStacksRequest {StackName = stackName}).Stacks.First();
+
+            SaveStackOutput(stack);
 
             return new Stack
             {
@@ -94,6 +97,24 @@ namespace TTC.Deployment.AmazonWebServices
             if (status != StackStatus.CREATE_COMPLETE)
             {
                 throw new FailedToCreateStackException(stackName, status.Value, statusReason);
+            }
+        }
+
+        void SaveStackOutput(Amazon.CloudFormation.Model.Stack stack)
+        {
+            if (stack.Outputs == null || stack.Outputs.Count == 0)
+                return;
+
+            var jsonOutput = new JObject();
+            foreach (var output in stack.Outputs)
+            {
+                jsonOutput.Add(output.OutputKey, JObject.Parse(output.OutputValue));
+            }
+
+            using (var file = File.CreateText(_awsConfiguration.StackOutputFile))
+            using (var writer = new JsonTextWriter(file))
+            {
+                jsonOutput.WriteTo(writer);
             }
         }
 

--- a/TTC.Deployment.AmazonWebServices/TTC.Deployment.AmazonWebServices.csproj
+++ b/TTC.Deployment.AmazonWebServices/TTC.Deployment.AmazonWebServices.csproj
@@ -36,6 +36,10 @@
       <HintPath>..\packages\AWSSDK.2.3.51.0\lib\net45\AWSSDK.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />

--- a/TTC.Deployment.AmazonWebServices/packages.config
+++ b/TTC.Deployment.AmazonWebServices/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AWSSDK" version="2.3.51.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/TTC.Deployment.Tests/ProvisioningTest.cs
+++ b/TTC.Deployment.Tests/ProvisioningTest.cs
@@ -73,7 +73,7 @@ namespace TTC.Deployment.Tests
                 {
                     if (outputInFile.Key == "Output1")
                     {
-                        Assert.AreEqual("Value1", outputInFile.Value.First.Value<string>());
+                        Assert.AreEqual("Value1", outputInFile.Value.ToString());
                     }
                 }
             }

--- a/TTC.Deployment.Tests/ProvisioningTest.cs
+++ b/TTC.Deployment.Tests/ProvisioningTest.cs
@@ -7,6 +7,7 @@ using Amazon;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using NUnit.Framework;
+using Newtonsoft.Json.Linq;
 using TTC.Deployment.AmazonWebServices;
 
 namespace TTC.Deployment.Tests
@@ -63,6 +64,19 @@ namespace TTC.Deployment.Tests
             }
 
             Assert.AreEqual(status, StackStatus.CREATE_COMPLETE);
+
+            using (var file = File.OpenText(_awsConfiguration.StackOutputFile))
+            {
+                var outputsInFile = JObject.Parse(file.ReadToEnd());
+
+                foreach (var outputInFile in outputsInFile)
+                {
+                    if (outputInFile.Key == "Output1")
+                    {
+                        Assert.AreEqual("Value1", outputInFile.Value.First.Value<string>());
+                    }
+                }
+            }
         }
 
         private void DeletePreviousTestStack()

--- a/TTC.Deployment.Tests/ProvisioningTest.cs
+++ b/TTC.Deployment.Tests/ProvisioningTest.cs
@@ -30,7 +30,8 @@ namespace TTC.Deployment.Tests
                 Bucket = "test-releases",
                 RoleName = "CodeDeployRole",
                 AwsEndpoint =  RegionEndpoint.USEast1,
-                Proxy = new AwsProxy()
+                Proxy = new AwsProxy(),
+                StackOutputFile = "StackOutput.json"
             };
             _cloudFormationClient = new AmazonCloudFormationClient(new AmazonCloudFormationConfig { RegionEndpoint = _awsConfiguration.AwsEndpoint });
             DeletePreviousTestStack();

--- a/TTC.Deployment.Tests/example-windows-vpc-template.json
+++ b/TTC.Deployment.Tests/example-windows-vpc-template.json
@@ -432,6 +432,10 @@
     "elasticIpUrl" : {
       "Value" : { "Fn::Join" : ["", ["http://", { "Ref" : "webServerEIP" } ]] },
       "Description" : "The public IP address"
+    },
+	"Output1" : {
+      "Value" : "Value1",
+      "Description" : "Some test output"
     }
   }
 }


### PR DESCRIPTION
Added option to save stack output to JSON file. 
This is required since certain output values form stack creation need to be known to other templates (e.g. blue-green template must know the VPC ID that is known only when the stack was created).