### PR TITLE
Always run tests as the same IAM user

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ The tag key is "DeploymentRole" and its value should be #{stack_name}_#{applicat
 
 Where ApiLayer is the name of the deployment group for a bundle
 
+## Running the tests
+
+  1. Create an IAM user called `aws-tools-tests`
+  2. Save a local AWS profile called `aws-tools-tests` with the aws access key
+     and secret corresponding to that IAM user (or alternatively use environment 
+     variables)
+  3. Give the user the permissions to do anything with EC2, IAM, CodeDeploy, and
+     CloudFormation.
+  4. Run the tests.
 
 ## License
 

--- a/TTC.Deployment.AmazonWebServices/AwsConfiguration.cs
+++ b/TTC.Deployment.AmazonWebServices/AwsConfiguration.cs
@@ -12,6 +12,8 @@ namespace TTC.Deployment.AmazonWebServices
         public RegionEndpoint AwsEndpoint { get; set; }
         public AwsProxy Proxy { get; set; }
         public AWSCredentials Credentials { get; set; }
+        public string ProxyHost { get { return Proxy == null ? null : Proxy.Host; } }
+        public int ProxyPort { get { return Proxy == null ? -1 : Proxy.Port; } }
     }
 
     public class AwsProxy 

--- a/TTC.Deployment.AmazonWebServices/Deployer.cs
+++ b/TTC.Deployment.AmazonWebServices/Deployer.cs
@@ -30,6 +30,7 @@ namespace TTC.Deployment.AmazonWebServices
             _awsConfiguration = awsConfiguration;
             _securityTokenServiceClient = new AmazonSecurityTokenServiceClient(_awsConfiguration.AwsEndpoint);
 
+            // TODO: don't use EnvironmentAWSCredentials, because it doesn't support environment variables!
             var credentials = awsConfiguration.Credentials ?? new EnvironmentAWSCredentials();
             
             if (!string.IsNullOrEmpty(_awsConfiguration.RoleName))

--- a/TTC.Deployment.AmazonWebServices/Deployer.cs
+++ b/TTC.Deployment.AmazonWebServices/Deployer.cs
@@ -50,40 +50,40 @@ namespace TTC.Deployment.AmazonWebServices
                 credentials,
                 new AmazonCodeDeployConfig {
                     RegionEndpoint = awsConfiguration.AwsEndpoint, 
-                    ProxyHost = awsConfiguration.Proxy.Host, 
-                    ProxyPort = awsConfiguration.Proxy.Port
+                    ProxyHost = awsConfiguration.ProxyHost, 
+                    ProxyPort = awsConfiguration.ProxyPort
                 });
 
             _cloudFormationClient = new AmazonCloudFormationClient(
                 credentials,
                 new AmazonCloudFormationConfig {
                     RegionEndpoint = awsConfiguration.AwsEndpoint, 
-                    ProxyHost = awsConfiguration.Proxy.Host, 
-                    ProxyPort = awsConfiguration.Proxy.Port
+                    ProxyHost = awsConfiguration.ProxyHost, 
+                    ProxyPort = awsConfiguration.ProxyPort
                 });
 
             _s3Client = new AmazonS3Client(
                 credentials,
                 new AmazonS3Config {
                     RegionEndpoint = awsConfiguration.AwsEndpoint, 
-                    ProxyHost = awsConfiguration.Proxy.Host, 
-                    ProxyPort = awsConfiguration.Proxy.Port
+                    ProxyHost = awsConfiguration.ProxyHost, 
+                    ProxyPort = awsConfiguration.ProxyPort
                 });
 
             _iamClient = new AmazonIdentityManagementServiceClient(
                 credentials,
                 new AmazonIdentityManagementServiceConfig  {
                     RegionEndpoint = awsConfiguration.AwsEndpoint, 
-                    ProxyHost = awsConfiguration.Proxy.Host, 
-                    ProxyPort = awsConfiguration.Proxy.Port
+                    ProxyHost = awsConfiguration.ProxyHost, 
+                    ProxyPort = awsConfiguration.ProxyPort
                 });
 
             _autoScalingClient = new AmazonAutoScalingClient(
                 credentials,
                 new AmazonAutoScalingConfig {
                     RegionEndpoint = awsConfiguration.AwsEndpoint,
-                    ProxyHost = awsConfiguration.Proxy.Host,
-                    ProxyPort = awsConfiguration.Proxy.Port
+                    ProxyHost = awsConfiguration.ProxyHost,
+                    ProxyPort = awsConfiguration.ProxyPort
                 });
         }
 

--- a/TTC.Deployment.Tests/AssumeRoleTest.cs
+++ b/TTC.Deployment.Tests/AssumeRoleTest.cs
@@ -47,8 +47,8 @@ namespace TTC.Deployment.Tests
                 new AmazonIdentityManagementServiceConfig
                 {
                     RegionEndpoint = _awsConfiguration.AwsEndpoint,
-                    ProxyHost = _awsConfiguration.Proxy.Host,
-                    ProxyPort = _awsConfiguration.Proxy.Port
+                    ProxyHost = _awsConfiguration.ProxyHost,
+                    ProxyPort = _awsConfiguration.ProxyPort
                 });
 
             _user = _iamClient.CreateUser(new CreateUserRequest

--- a/TTC.Deployment.Tests/AssumeRoleTest.cs
+++ b/TTC.Deployment.Tests/AssumeRoleTest.cs
@@ -23,26 +23,24 @@ namespace TTC.Deployment.Tests
         AmazonS3Client _s3Client;
         User _user;
         BasicAWSCredentials _userCredentials;
-        string _accessKeyId;
-        string _userName;
+        
         Role _role;
         string _roleName;
-        string _bucketName;
+
+        private readonly string _userName = "aws_tools_assume_role_test_user";
+        private readonly string _bucketName = "aws-tools-test-bucket-1";
 
         [SetUp]
         public void SetUp()
         {
-            _userName = "test_user_21";
             _roleName = "assume-role-" + DateTime.Now.ToFileTime();
-            _bucketName = "aws-tools-test-bucket-1";
 
             _awsConfiguration = new AwsConfiguration
             {
                 AwsEndpoint = RegionEndpoint.USWest2,
                 Credentials = new TestSuiteCredentials()
             };
-            DeletePreviousTestStack();
-
+            
             _iamClient = new AmazonIdentityManagementServiceClient(
                 new AmazonIdentityManagementServiceConfig
                 {
@@ -50,6 +48,10 @@ namespace TTC.Deployment.Tests
                     ProxyHost = _awsConfiguration.ProxyHost,
                     ProxyPort = _awsConfiguration.ProxyPort
                 });
+
+            _s3Client = new AmazonS3Client(new AmazonS3Config { RegionEndpoint = _awsConfiguration.AwsEndpoint });
+
+            DeletePreviousTestStack();
 
             _user = _iamClient.CreateUser(new CreateUserRequest
             {
@@ -84,13 +86,14 @@ namespace TTC.Deployment.Tests
                 }"
             });
 
-            var accessKey = _iamClient.CreateAccessKey(new CreateAccessKeyRequest
-            {
-                UserName = _user.UserName
-            }).AccessKey;
-
-            _accessKeyId = accessKey.AccessKeyId;
+            var accessKey = _iamClient.CreateAccessKey(new CreateAccessKeyRequest { UserName = _user.UserName }).AccessKey;
             _userCredentials = new BasicAWSCredentials(accessKey.AccessKeyId, accessKey.SecretAccessKey);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            DeletePreviousTestStack();
         }
 
         [Test]
@@ -145,84 +148,98 @@ namespace TTC.Deployment.Tests
 
             _awsConfiguration.RoleName = _role.Arn;
             var deployer = new Deployer(_awsConfiguration);
-             deployer.CreateStack(new StackTemplate {
+            deployer.CreateStack(new StackTemplate {
        
                 StackName = "SimpleBucketTestStack",
                 TemplatePath = CloudFormationTemplates.Path("simple-s3-bucket-template.json"),
                 AssumedRoleARN = _role.Arn
             });
 
-            _s3Client = new AmazonS3Client(
-                new AmazonS3Config
-                {
-                    RegionEndpoint =_awsConfiguration.AwsEndpoint
-                });
-
             var s3Response = _s3Client.GetBucketLocation(_bucketName);
             Assert.AreEqual(s3Response.HttpStatusCode, HttpStatusCode.OK);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            DeleteRole("some_role_that_is_no_good_test");
-            var userPolicies = _iamClient.ListUserPolicies(new ListUserPoliciesRequest { UserName = _userName }).PolicyNames;
-            foreach (var policy in userPolicies)
-            {
-                _iamClient.DeleteUserPolicy(new DeleteUserPolicyRequest
-                {
-                    UserName = _userName,
-                    PolicyName = policy
-                });
-            }
-            _iamClient.DeleteAccessKey(new DeleteAccessKeyRequest
-            {
-                UserName = _userName,
-                AccessKeyId = _accessKeyId
-            });
-            _iamClient.DeleteUser(new DeleteUserRequest { UserName = _userName });
-
-            try
-            {
-                _s3Client.DeleteBucket(_bucketName);
-            } catch { }
         }
 
         private void DeleteRole(string roleName)
         {
             try
             {
-                var roleResponse = _iamClient.GetRole(new GetRoleRequest
-                {
-                    RoleName = roleName
-                });
+                _iamClient.GetRole(new GetRoleRequest {RoleName = roleName});
+            }
+            catch (NoSuchEntityException)
+            {
+                return;
+            }
 
-                if (roleResponse.Role == null) return;
+            var rolePoliciesResponse = _iamClient.ListRolePolicies(new ListRolePoliciesRequest { RoleName = roleName });
 
-                var rolePoliciesResponse = _iamClient.ListRolePolicies(new ListRolePoliciesRequest
-                {
-                    RoleName = roleName
-                });
-           
-                foreach(var p in rolePoliciesResponse.PolicyNames)
-                {
-                    _iamClient.DeleteRolePolicy(new DeleteRolePolicyRequest
-                    {
-                        PolicyName = p,
-                        RoleName = roleName
-                    });
-                } 
-            
-                _iamClient.DeleteRole(new DeleteRoleRequest
-                {
-                    RoleName = roleName
-                });
-            } catch { }
+            foreach (var p in rolePoliciesResponse.PolicyNames)
+            {
+                var request = new DeleteRolePolicyRequest { PolicyName = p, RoleName = roleName };
+                IgnoringNoSuchEntity(() => _iamClient.DeleteRolePolicy(request));
+            }
+
+            IgnoringNoSuchEntity(() => _iamClient.DeleteRole(new DeleteRoleRequest { RoleName = roleName }));
         }
 
         private void DeletePreviousTestStack()
         {
+            DeleteRole("some_role_that_is_no_good_test");
+            DeleteUser(_userName);
             StackHelper.DeleteStack(_awsConfiguration.AwsEndpoint, "SimpleBucketTestStack");
+            IgnoringNoSuchBucket(() => _s3Client.DeleteBucket(_bucketName));
+        }
+
+        private void DeleteUser(string userName)
+        {
+            try
+            {
+                var userPolicies =
+                    _iamClient.ListUserPolicies(new ListUserPoliciesRequest {UserName = userName}).PolicyNames;
+
+                foreach (var policy in userPolicies)
+                {
+                    var request = new DeleteUserPolicyRequest {UserName = userName, PolicyName = policy};
+                    IgnoringNoSuchEntity(() => { _iamClient.DeleteUserPolicy(request); });
+                }
+            }
+            catch (NoSuchEntityException)
+            {
+                return;
+            }
+
+            var keys = _iamClient.ListAccessKeys(new ListAccessKeysRequest { UserName = _userName });
+
+            foreach (var key in keys.AccessKeyMetadata)
+            {
+                var request = new DeleteAccessKeyRequest { UserName = userName, AccessKeyId = key.AccessKeyId };
+                IgnoringNoSuchEntity(() => { _iamClient.DeleteAccessKey(request); });
+            }
+
+            IgnoringNoSuchEntity(() => _iamClient.DeleteUser(new DeleteUserRequest { UserName = userName }));
+        }
+
+        private void IgnoringNoSuchEntity(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (NoSuchEntityException)
+            {
+                Console.WriteLine("Ignoring no such entity...");
+            }
+        }
+
+        private void IgnoringNoSuchBucket(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (AmazonS3Exception)
+            {
+                Console.WriteLine("Ignoring no such bucket...");
+            }
         }
 
         private string GetAWSAccountIdFromArn(User user)

--- a/TTC.Deployment.Tests/AssumeRoleTest.cs
+++ b/TTC.Deployment.Tests/AssumeRoleTest.cs
@@ -8,7 +8,6 @@ using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
 using NUnit.Framework;
 using System;
-using System.Configuration;
 using System.Net;
 using System.Threading;
 using TTC.Deployment.AmazonWebServices;
@@ -40,7 +39,7 @@ namespace TTC.Deployment.Tests
             _awsConfiguration = new AwsConfiguration
             {
                 AwsEndpoint = RegionEndpoint.USWest2,
-                Proxy = new AwsProxy()
+                Credentials = new TestSuiteCredentials()
             };
             DeletePreviousTestStack();
 

--- a/TTC.Deployment.Tests/AssumeRoleTest.cs
+++ b/TTC.Deployment.Tests/AssumeRoleTest.cs
@@ -33,7 +33,6 @@ namespace TTC.Deployment.Tests
         [SetUp]
         public void SetUp()
         {
-            ConfigurationManager.AppSettings["AWSProfileName"] = "default";
             _userName = "test_user_21";
             _roleName = "assume-role-" + DateTime.Now.ToFileTime();
             _bucketName = "aws-tools-test-bucket-1";

--- a/TTC.Deployment.Tests/AutoScalingDeploymentTest.cs
+++ b/TTC.Deployment.Tests/AutoScalingDeploymentTest.cs
@@ -20,7 +20,6 @@ namespace TTC.Deployment.Tests
         {
             if (_hasCreatedStack) return;
 
-            ConfigurationManager.AppSettings["AWSProfileName"] = "default";
             _awsConfiguration = new AwsConfiguration
             {
                 AssumeRoleTrustDocument = Roles.Path("code-deploy-trust.json"),

--- a/TTC.Deployment.Tests/AutoScalingDeploymentTest.cs
+++ b/TTC.Deployment.Tests/AutoScalingDeploymentTest.cs
@@ -27,7 +27,7 @@ namespace TTC.Deployment.Tests
                 Bucket = "aws-deployment-tools-tests",
                 RoleName = "CodeDeployRole",
                 AwsEndpoint = RegionEndpoint.USWest2,
-                Proxy = new AwsProxy()
+                Credentials = new TestSuiteCredentials()
             };
 
             _deployer = new Deployer(_awsConfiguration);

--- a/TTC.Deployment.Tests/CloudFormationTemplates/example-windows-vpc-autoscaling-group-template.json
+++ b/TTC.Deployment.Tests/CloudFormationTemplates/example-windows-vpc-autoscaling-group-template.json
@@ -77,7 +77,7 @@
 	  "CreationPolicy": {
 		"ResourceSignal": {
 		  "Count": "1",
-		  "Timeout": "PT30M"
+		  "Timeout": "PT35M"
 		}
 	  },
       "Properties": {

--- a/TTC.Deployment.Tests/CloudFormationTemplates/example-windows-vpc-template.json
+++ b/TTC.Deployment.Tests/CloudFormationTemplates/example-windows-vpc-template.json
@@ -69,7 +69,7 @@
 			"CreationPolicy" : {
 				"ResourceSignal" : {
 					"Count" : "1",
-					"Timeout" : "PT30M"
+					"Timeout" : "PT35M"
 				}
 			},
             "Properties": {
@@ -155,7 +155,7 @@
 			"CreationPolicy" : {
 				"ResourceSignal" : {
 					"Count" : "1",
-					"Timeout" : "PT30M"
+					"Timeout" : "PT35M"
 				}
 			},
             "Properties": {

--- a/TTC.Deployment.Tests/DeploymentTest.cs
+++ b/TTC.Deployment.Tests/DeploymentTest.cs
@@ -21,7 +21,6 @@ namespace TTC.Deployment.Tests
         {
             if (_hasCreatedStack) return;
 
-            ConfigurationManager.AppSettings["AWSProfileName"] = "default";
             _awsConfiguration = new AwsConfiguration
             {
                 AssumeRoleTrustDocument = Roles.Path("code-deploy-trust.json"),

--- a/TTC.Deployment.Tests/DeploymentTest.cs
+++ b/TTC.Deployment.Tests/DeploymentTest.cs
@@ -14,7 +14,7 @@ namespace TTC.Deployment.Tests
         private Deployer _deployer;
         private Stack _stack;
         const string StackName = "AwsToolsTestVPC";
-        static private bool _hasCreatedStack;
+        private static bool _hasCreatedStack;
 
         [SetUp]
         public void EnsureStackExists()
@@ -28,7 +28,7 @@ namespace TTC.Deployment.Tests
                 Bucket = "aws-deployment-tools-tests",
                 RoleName = "CodeDeployRole",
                 AwsEndpoint = RegionEndpoint.USWest2,
-                Proxy = new AwsProxy()
+                Credentials = new TestSuiteCredentials()
             };
 
             _deployer = new Deployer(_awsConfiguration);

--- a/TTC.Deployment.Tests/EnsureRunningAsSpecialAwsToolsTestUser.cs
+++ b/TTC.Deployment.Tests/EnsureRunningAsSpecialAwsToolsTestUser.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace TTC.Deployment.Tests
 {
     [SetUpFixture]
-    public class SuiteSetUp
+    public class EnsureRunningAsSpecialAwsToolsTestUser
     {
         [SetUp]
         public void	CheckWeAreRunningAsTheSpecialUser()

--- a/TTC.Deployment.Tests/EnsureRunningAsSpecialAwsToolsTestUser.cs
+++ b/TTC.Deployment.Tests/EnsureRunningAsSpecialAwsToolsTestUser.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.IdentityManagement;
+﻿using System.Configuration;
+using Amazon.IdentityManagement;
 using NUnit.Framework;
 
 namespace TTC.Deployment.Tests
@@ -7,8 +8,9 @@ namespace TTC.Deployment.Tests
     public class EnsureRunningAsSpecialAwsToolsTestUser
     {
         [SetUp]
-        public void	CheckWeAreRunningAsTheSpecialUser()
+        public void CheckWeAreRunningAsTheSpecialUser()
 	    {
+            ConfigurationManager.AppSettings["AWSProfileName"] = "aws-tools-tests";
             var iamClient = new AmazonIdentityManagementServiceClient();
             var me = iamClient.GetUser();
             Assert.That(me.User.UserName, Is.EqualTo("aws-tools-tests"));

--- a/TTC.Deployment.Tests/ProvisioningTest.cs
+++ b/TTC.Deployment.Tests/ProvisioningTest.cs
@@ -22,7 +22,7 @@ namespace TTC.Deployment.Tests
             _awsConfiguration = new AwsConfiguration
             {
                 AwsEndpoint = RegionEndpoint.USWest2,
-                Proxy = new AwsProxy()
+                Credentials = new TestSuiteCredentials()
             };
             _cloudFormationClient = new AmazonCloudFormationClient(new AmazonCloudFormationConfig { RegionEndpoint = _awsConfiguration.AwsEndpoint });
             DeletePreviousTestStack();

--- a/TTC.Deployment.Tests/ProvisioningTest.cs
+++ b/TTC.Deployment.Tests/ProvisioningTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 using System.Linq;
 using System.Threading;
 using Amazon;
@@ -20,8 +19,6 @@ namespace TTC.Deployment.Tests
         [SetUp]
         public void SetUp()
         {
-            ConfigurationManager.AppSettings["AWSProfileName"] = "default";
-           
             _awsConfiguration = new AwsConfiguration
             {
                 AwsEndpoint = RegionEndpoint.USWest2,

--- a/TTC.Deployment.Tests/PushTest.cs
+++ b/TTC.Deployment.Tests/PushTest.cs
@@ -31,7 +31,8 @@ namespace TTC.Deployment.Tests
                 Bucket = "s3-push-test",
                 RoleName = "SomeNewRole",
                 AwsEndpoint = RegionEndpoint.USWest2,
-                Proxy = new AwsProxy()
+                Proxy = new AwsProxy(),
+                Credentials = new TestSuiteCredentials()
             };
             _s3Client = new AmazonS3Client(_awsConfiguration.AwsEndpoint);
             _iamClient = new AmazonIdentityManagementServiceClient(_awsConfiguration.AwsEndpoint);

--- a/TTC.Deployment.Tests/PushTest.cs
+++ b/TTC.Deployment.Tests/PushTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Configuration;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using Amazon;
 using Amazon.IdentityManagement;

--- a/TTC.Deployment.Tests/SuiteSetUp.cs
+++ b/TTC.Deployment.Tests/SuiteSetUp.cs
@@ -1,0 +1,17 @@
+﻿using Amazon.IdentityManagement;
+using NUnit.Framework;
+
+namespace TTC.Deployment.Tests
+{
+    [SetUpFixture]
+    public class SuiteSetUp
+    {
+        [SetUp]
+        public void	CheckWeAreRunningAsTheSpecialUser()
+	    {
+            var iamClient = new AmazonIdentityManagementServiceClient();
+            var me = iamClient.GetUser();
+            Assert.That(me.User.UserName, Is.EqualTo("aws-tools-tests"));
+	    }
+    }
+}

--- a/TTC.Deployment.Tests/TTC.Deployment.Tests.csproj
+++ b/TTC.Deployment.Tests/TTC.Deployment.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Retry.cs" />
     <Compile Include="Roles.cs" />
     <Compile Include="StackHelper.cs" />
+    <Compile Include="SuiteSetUp.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.config" />

--- a/TTC.Deployment.Tests/TTC.Deployment.Tests.csproj
+++ b/TTC.Deployment.Tests/TTC.Deployment.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Roles.cs" />
     <Compile Include="StackHelper.cs" />
     <Compile Include="EnsureRunningAsSpecialAwsToolsTestUser.cs" />
+    <Compile Include="TestSuiteCredentials.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.config" />

--- a/TTC.Deployment.Tests/TTC.Deployment.Tests.csproj
+++ b/TTC.Deployment.Tests/TTC.Deployment.Tests.csproj
@@ -64,7 +64,7 @@
     <Compile Include="Retry.cs" />
     <Compile Include="Roles.cs" />
     <Compile Include="StackHelper.cs" />
-    <Compile Include="SuiteSetUp.cs" />
+    <Compile Include="EnsureRunningAsSpecialAwsToolsTestUser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.config" />

--- a/TTC.Deployment.Tests/TestSuiteCredentials.cs
+++ b/TTC.Deployment.Tests/TestSuiteCredentials.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Amazon.Runtime;
+
+namespace TTC.Deployment.Tests
+{
+    public class TestSuiteCredentials : AWSCredentials
+    {
+        private readonly ImmutableCredentials _creds;
+
+        public TestSuiteCredentials()
+        {
+            _creds = ReadCredentialsFromEnvironmentVariablesOrStoredProfile();
+        }
+
+        public override ImmutableCredentials GetCredentials()
+        {
+            return _creds;
+        }
+
+        private static ImmutableCredentials ReadCredentialsFromEnvironmentVariablesOrStoredProfile()
+        {
+            try
+            {
+                return new EnvironmentVariablesAWSCredentials().GetCredentials();
+            }
+            catch (InvalidOperationException)
+            {
+                return new StoredProfileAWSCredentials("aws-tools-tests").GetCredentials();
+            }
+        }
+    }
+}


### PR DESCRIPTION
We were seeing discrepancies between local and CI test runs, so...

* Changed all tests to use a special credentials implementation that looks at standard AWS environment variables first, and if those aren't set, uses an aws profile called "aws-tools-tests". This is a simple way to avoid storing credentials on build agent machines (that have IAM roles assigned to them) but still use credentials locally (where machines cannot have IAM roles assigned to them).

* Assert the tests are actually running as an IAM user called "aws-tools-tests", so that everybody including developers and CI machines are guaranteed to run tests with the same account.

* Improved error handling in AssumeRoleTest so that it cleans up after itself better.